### PR TITLE
Removed whitespace before parenthesis to fix ruby warning

### DIFF
--- a/lib/corba/common/ORB.rb
+++ b/lib/corba/common/ORB.rb
@@ -259,7 +259,7 @@ module R2CORBA
       # Identifier name
       # TypeCode boxed_type
       # ret TypeCode
-      def create_value_box_tc (id, name, boxed_type)
+      def create_value_box_tc(id, name, boxed_type)
         return CORBA::TypeCode::Valuebox.new(id, name, boxed_type)
       end
 


### PR DESCRIPTION
    * lib/corba/common/ORB.rb: