### PR TITLE
Undefine memcpy when it has been defined by ruby as macro (ruby 2.7.2…

### DIFF
--- a/ext/libr2tao/required.h
+++ b/ext/libr2tao/required.h
@@ -45,6 +45,9 @@
 #if defined (access)
 # undef access
 #endif
+#if defined (memcpy)
+# undef memcpy
+#endif
 
 #undef RUBY_METHOD_FUNC
 extern "C" {


### PR DESCRIPTION
… does that for example)

    * ext/libr2tao/required.h: