### PR TITLE
Use matrix on linux and windows gem release only with ruby 2.7

### DIFF
--- a/.github/workflows/gem_release.yml
+++ b/.github/workflows/gem_release.yml
@@ -6,13 +6,17 @@ on:
 
 jobs:
   linux:
-    name: Publish
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: [ '2.7' ]
+    name: ${{ matrix.os }} ruby-${{ matrix.ruby }}
     steps:
     - uses: actions/checkout@master
     - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: '2.7'
+        ruby-version: ${{ matrix.ruby }}
     - name: Publish to RubyGems
       run: |
         rake gem
@@ -26,7 +30,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ '2.4', '2.5', '2.6', '2.7', '3.0' ]
+        ruby: [ '2.7' ]
     name: ${{ matrix.runs-os }} ${{ matrix.msystem }} ruby-${{ matrix.ruby }}
     env:
       DOC_ROOT: ${{ github.workspace }}/ACE


### PR DESCRIPTION
    * .github/workflows/gem_release.yml: