### PR TITLE
Add support for RIDL_ROOT

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -24,11 +24,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - CC: gcc-4.8
-            CXX: g++-4.8
-            PackageDeps: g++-4.8
-            os: ubuntu-18.04
-            ruby: '2.4'
           - CC: gcc-6
             CXX: g++-6
             PackageDeps: g++-6
@@ -37,12 +32,12 @@ jobs:
           - CC: gcc-7
             CXX: g++-7
             PackageDeps: g++-7
-            os: ubuntu-18.04
+            os: ubuntu-20.04
             ruby: '2.6'
           - CC: gcc-8
             CXX: g++-8
             PackageDeps: g++-8
-            os: ubuntu-18.04
+            os: ubuntu-20.04
             ruby: '2.7'
           - CC: gcc-9
             CXX: g++-9
@@ -57,18 +52,18 @@ jobs:
           - CC: gcc-11
             CXX: g++-11
             PackageDeps: g++-11
-            os: ubuntu-20.04
+            os: ubuntu-22.04
             ruby: '3.0'
           - CC: gcc-11
             CXX: g++-11
             PackageDeps: g++-11
-            os: ubuntu-20.04
+            os: ubuntu-22.04
             ruby: '3.1'
           - feature: CodeQL
             CC: gcc-11
             CXX: g++-11
             PackageDeps: g++-11
-            os: ubuntu-20.04
+            os: ubuntu-22.04
             ruby: '3.1'
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.os }} ${{ matrix.CXX }} ruby-${{ matrix.ruby }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ '2.4', '2.5', '2.6', '2.7', '3.0', '3.1' ]
+        ruby: [ '2.5', '2.6', '2.7', '3.0', '3.1' ]
     name: ${{ matrix.runs-os }} ${{ matrix.msystem }} ruby-${{ matrix.ruby }}
     env:
       DOC_ROOT: ${{ github.workspace }}/ACE

--- a/INSTALL
+++ b/INSTALL
@@ -9,7 +9,7 @@ Ruby MRI 2.4 or newer
   https://rubyinstaller.org/downloads (Windows binaries) if not available as
   a standard package on your platform.
 
-ACE+TAO 7.0.3
+ACE+TAO 7.0.11
   Download latest micro release from https://github.com/DOCGroup/ACE_TAO/releases
   (select a source only package containing ACE+TAO)
 
@@ -111,6 +111,9 @@ for the ACE+TAO libraries from the extension build process.
 This can be used on a system which already has a compatible ACE+TAO version installed
 (needs to find the ACE+TAO dlls in the dynamic library search path for the platform
  as well as the include files in the regular includes location).
+
+ridl is expected in the ridl subdirectory. This can be overruled using the RIDL_ROOT
+environment variable.
 
 NOTE: Please be aware the rake tasks still need an accessible ACE/TAO installation.
 

--- a/INSTALL.jruby
+++ b/INSTALL.jruby
@@ -27,7 +27,7 @@ Simple configuration
 
 - download a JacORB binary package
 - create a 'jacorb' subdirectory under the 'r2corba' directory created by unpacking
-  the Ruby2CORBA distribution package 
+  the Ruby2CORBA distribution package
 - unpack the JacORB package under the 'jacorb' subdirectory creating 'bin', 'lib',
   'etc' and other subdirectories
 - configure the build by executing the command:
@@ -58,19 +58,22 @@ Running the command 'rake -- configure --help' will output information showing a
 the available options to customize configuration
 
 The optional configure parameter '--jacorb_home=<path>' can be used to specify a
-different location of the JacORB tree than under the default 
+different location of the JacORB tree than under the default
 ./<r2corba dir>/jacorb directory.
 
 Alternatively the environment variable JACORB_HOME can be set to the JacORB
 path. If the configure task cannot find JacORB at ./<r2corba dir>/jacorb and no
-'--jacorb_home' parameter is specified it will use the value of this environment 
+'--jacorb_home' parameter is specified it will use the value of this environment
 variable if set.
 
 The optional configure parameter '--without-jacorb' will exclude the install steps for the
 JacORB libraries (JAR files) from the extension installation process.
 This can be used on a system which already has a compatible JacORB version installed
-(needs JACORB_HOME to be set to the JacORB install location for R2CORBA to find the 
+(needs JACORB_HOME to be set to the JacORB install location for R2CORBA to find the
  JAR files).
+
+ridl is expected in the ridl subdirectory. This can be overruled using the RIDL_ROOT
+environment variable.
 
 NOTE: Please be aware the rake tasks still need an accessible JacORB installation.
 

--- a/rakelib/config.rb
+++ b/rakelib/config.rb
@@ -346,10 +346,12 @@ module R2CORBA
 
       @@ridlc = File.join('bin', 'ridlc')
 
-      # check availability of RIDL; either as gem or in subdir
-      if (@@ridl_local = File.exist?(File.join('ridl', 'lib', 'ridl', 'ridl.rb')))
+      # check availability of RIDL; either as gem or in ridl subdir, or to a location as set
+      # in the RIDL_ROOT environment variable
+      ENV['RIDL_ROOT'] ||= File.expand_path('ridl')
+      if (@@ridl_local = File.exist?(File.join(ENV['RIDL_ROOT'], 'lib', 'ridl', 'ridl.rb')))
         incdirs = [
-            File.expand_path(File.join('ridl', 'lib')),
+            File.expand_path(File.join(ENV['RIDL_ROOT'], 'lib')),
             File.expand_path('lib'),
             ENV['RUBYLIB']
         ].compact
@@ -513,9 +515,10 @@ module R2CORBA
         end
       end
 
-      # check availability of RIDL; either as gem or in subdir
-      unless File.exist?(File.join('ridl', 'lib', 'ridl', 'ridl.rb')) || (`gem search -i -q ridl`.strip) == 'true'
-        raise 'Missing RIDL installation. R2CORBA requires RIDL installed either as gem or in subdirectory ridl.'
+      # check availability of RIDL; either as gem or in subdir or as set in RIDL_ROOT
+      ENV['RIDL_ROOT'] ||= File.expand_path('ridl')
+      unless File.exist?(File.join(ENV['RIDL_ROOT'], 'lib', 'ridl', 'ridl.rb')) || (`gem search -i -q ridl`.strip) == 'true'
+        raise 'Missing RIDL installation. R2CORBA requires RIDL installed either as gem or in the subdirectory ridl, or at the location as set by RIDL_ROOT.'
       end
     end
 

--- a/test/test_runner.rb
+++ b/test/test_runner.rb
@@ -23,11 +23,11 @@ is_win32 = (RB_CONFIG['target_os'] =~ /win32/ || RB_CONFIG['target_os'] =~ /ming
 
 root_path = File.expand_path(File.join(File.dirname(__FILE__), '..'))
 
-has_local_ridl = File.directory?(File.join(root_path, 'ridl'))
+ENV['RIDL_ROOT'] ||= File.expand_path(File.join(root_path, 'ridl'))
+has_local_ridl = File.directory?(ENV['RIDL_ROOT'])
 
 if defined?(JRUBY_VERSION)
   ENV['JACORB_HOME'] ||= File.expand_path(File.join(root_path, 'jacorb'))
-  ENV['RIDL_ROOT'] ||= File.expand_path(File.join(root_path, 'ridl'))
   incdirs = [
       has_local_ridl ? File.expand_path(File.join(ENV['RIDL_ROOT'], 'lib')) : nil,
       File.expand_path(File.join(root_path, 'lib')),
@@ -39,7 +39,6 @@ if defined?(JRUBY_VERSION)
   ENV['RUBYLIB'] = incdirs.join(File::PATH_SEPARATOR)
 else
   ace_root = ENV['ACE_ROOT'] || File.expand_path(File.join(root_path, 'ACE', 'ACE_wrappers'))
-  ENV['RIDL_ROOT'] ||= File.expand_path(File.join(root_path, 'ridl'))
   ## setup the right environment for running tests
   incdirs = [
       has_local_ridl ? File.expand_path(File.join(ENV['RIDL_ROOT'], 'lib')) : nil,

--- a/test/test_runner.rb
+++ b/test/test_runner.rb
@@ -27,8 +27,9 @@ has_local_ridl = File.directory?(File.join(root_path, 'ridl'))
 
 if defined?(JRUBY_VERSION)
   ENV['JACORB_HOME'] ||= File.expand_path(File.join(root_path, 'jacorb'))
+  ENV['RIDL_ROOT'] ||= File.expand_path(File.join(root_path, 'ridl'))
   incdirs = [
-      has_local_ridl ? File.expand_path(File.join(root_path, 'ridl', 'lib')) : nil,
+      has_local_ridl ? File.expand_path(File.join(ENV['RIDL_ROOT'], 'lib')) : nil,
       File.expand_path(File.join(root_path, 'lib')),
       File.expand_path(File.join(root_path, 'ext')),
       File.expand_path(File.join(ENV['JACORB_HOME'], 'lib')),
@@ -38,9 +39,10 @@ if defined?(JRUBY_VERSION)
   ENV['RUBYLIB'] = incdirs.join(File::PATH_SEPARATOR)
 else
   ace_root = ENV['ACE_ROOT'] || File.expand_path(File.join(root_path, 'ACE', 'ACE_wrappers'))
+  ENV['RIDL_ROOT'] ||= File.expand_path(File.join(root_path, 'ridl'))
   ## setup the right environment for running tests
   incdirs = [
-      has_local_ridl ? File.expand_path(File.join(root_path, 'ridl', 'lib')) : nil,
+      has_local_ridl ? File.expand_path(File.join(ENV['RIDL_ROOT'], 'lib')) : nil,
       File.expand_path(File.join(root_path, 'lib')),
       File.expand_path(File.join(root_path, 'ext')),
       ENV['RUBYLIB'],


### PR DESCRIPTION
Add support for RIDL_ROOT environment variable to set the location of a local ridl tree, needed for adding r2corba to the github action CI for ridl