### PR TITLE
Use File.open as Kernel.open is non secure

### DIFF
--- a/test/BiDirectional/server.rb
+++ b/test/BiDirectional/server.rb
@@ -138,7 +138,7 @@ ior = orb.object_to_string(obj)
 
 puts "Activated as <#{ior}>"
 
-open(OPTIONS[:iorfile], 'w') { |io|
+File.open(OPTIONS[:iorfile], 'w') { |io|
   io.write ior
 }
 

--- a/test/CORBA_Services/Naming/Corbaname/server.rb
+++ b/test/CORBA_Services/Naming/Corbaname/server.rb
@@ -116,7 +116,7 @@ sn = nc.to_string(name)             # stringify name
 corbaname = nc.to_url(ins_url, sn)  # corbaname url
 
 # write corbaname to file
-open(OPTIONS[:iorfile], 'w') { |io|
+File.open(OPTIONS[:iorfile], 'w') { |io|
   io.write corbaname
 }
 

--- a/test/DII/server.rb
+++ b/test/DII/server.rb
@@ -78,7 +78,7 @@ hello_obj = hello_srv._this()
 
 hello_ior = orb.object_to_string(hello_obj)
 
-open(OPTIONS[:iorfile], 'w') { |io|
+File.open(OPTIONS[:iorfile], 'w') { |io|
   io.write hello_ior
 }
 

--- a/test/DSI/client.rb
+++ b/test/DSI/client.rb
@@ -50,7 +50,7 @@ end
 
 orb = CORBA.ORB_init(['-ORBDebugLevel', OPTIONS[:orb_debuglevel]], 'myORB')
 
-# #s = open(OPTIONS[:iorfile], 'r').read
+# #s = File.open(OPTIONS[:iorfile], 'r').read
 
 obj = orb.string_to_object(OPTIONS[:iorfile])
 

--- a/test/DSI/server.rb
+++ b/test/DSI/server.rb
@@ -89,7 +89,7 @@ hello_obj = hello_srv._this()
 
 hello_ior = orb.object_to_string(hello_obj)
 
-open(OPTIONS[:iorfile], 'w') { |io|
+File.open(OPTIONS[:iorfile], 'w') { |io|
   io.write hello_ior
 }
 

--- a/test/Exceptions/server.rb
+++ b/test/Exceptions/server.rb
@@ -112,7 +112,7 @@ hello_obj = hello_srv._this()
 
 hello_ior = orb.object_to_string(hello_obj)
 
-open(OPTIONS[:iorfile], 'w') { |io|
+File.open(OPTIONS[:iorfile], 'w') { |io|
   io.write hello_ior
 }
 

--- a/test/Hello/server.rb
+++ b/test/Hello/server.rb
@@ -78,7 +78,7 @@ hello_obj = hello_srv._this()
 
 hello_ior = orb.object_to_string(hello_obj)
 
-open(OPTIONS[:iorfile], 'w') { |io|
+File.open(OPTIONS[:iorfile], 'w') { |io|
   io.write hello_ior
 }
 

--- a/test/IDL_Test/server.rb
+++ b/test/IDL_Test/server.rb
@@ -87,7 +87,7 @@ hello_obj = hello_srv._this()
 
 hello_ior = orb.object_to_string(hello_obj)
 
-open(OPTIONS[:iorfile], 'w') { |io|
+File.open(OPTIONS[:iorfile], 'w') { |io|
   io.write hello_ior
 }
 

--- a/test/IORMap/server.rb
+++ b/test/IORMap/server.rb
@@ -97,7 +97,7 @@ hello_ior = orb.object_to_string(hello_obj)
 
 orb.ior_map.map_ior('Hello2', hello_ior)
 
-open(OPTIONS[:iorfile], 'w') { |io|
+File.open(OPTIONS[:iorfile], 'w') { |io|
   io.write hello_ior
 }
 

--- a/test/IORTable/server.rb
+++ b/test/IORTable/server.rb
@@ -52,7 +52,7 @@ else
   require 'TestS.rb'
 end
 
-begin STDERR.puts 'Not supported on this platform'; open(OPTIONS[:iorfile], 'w') {|io|io.write ''}; exit(0); end unless defined?(IORTable)
+begin STDERR.puts 'Not supported on this platform'; File.open(OPTIONS[:iorfile], 'w') {|io|io.write ''}; exit(0); end unless defined?(IORTable)
 
 class MyHello < POA::Test::Hello
   def initialize(orb, id)
@@ -113,7 +113,7 @@ hello_ior = orb.object_to_string(hello_obj)
 
 iortbl.set_locator(MyLocator.new('Hello2', hello_ior))
 
-open(OPTIONS[:iorfile], 'w') { |io|
+File.open(OPTIONS[:iorfile], 'w') { |io|
   io.write hello_ior
 }
 

--- a/test/Implicit_Conversion/server.rb
+++ b/test/Implicit_Conversion/server.rb
@@ -82,7 +82,7 @@ hello_obj = hello_srv._this()
 
 hello_ior = orb.object_to_string(hello_obj)
 
-open(OPTIONS[:iorfile], 'w') { |io|
+File.open(OPTIONS[:iorfile], 'w') { |io|
   io.write hello_ior
 }
 

--- a/test/Multi_Threading/Simple/server.rb
+++ b/test/Multi_Threading/Simple/server.rb
@@ -78,7 +78,7 @@ hello_obj = hello_srv._this()
 
 hello_ior = orb.object_to_string(hello_obj)
 
-open(OPTIONS[:iorfile], 'w') { |io|
+File.open(OPTIONS[:iorfile], 'w') { |io|
   io.write hello_ior
 }
 

--- a/test/Multi_Threading/Threads/server.rb
+++ b/test/Multi_Threading/Threads/server.rb
@@ -100,7 +100,7 @@ hello_obj = hello_srv._this()
 
 hello_ior = orb.object_to_string(hello_obj)
 
-open(OPTIONS[:iorfile], 'w') { |io|
+File.open(OPTIONS[:iorfile], 'w') { |io|
   io.write hello_ior
 }
 

--- a/test/Multi_Threading/Threads/watchdog.rb
+++ b/test/Multi_Threading/Threads/watchdog.rb
@@ -71,7 +71,7 @@ obj = srv._this()
 
 ior = orb.object_to_string(obj)
 
-open(OPTIONS[:iorfile], 'w') { |io|
+File.open(OPTIONS[:iorfile], 'w') { |io|
   io.write ior
 }
 

--- a/test/Multiple_Servant_Interfaces/server.rb
+++ b/test/Multiple_Servant_Interfaces/server.rb
@@ -85,7 +85,7 @@ hello_obj = hello_srv._this()
 
 hello_ior = orb.object_to_string(hello_obj)
 
-open(OPTIONS[:iorfile], 'w') { |io|
+File.open(OPTIONS[:iorfile], 'w') { |io|
   io.write hello_ior
 }
 

--- a/test/OBV/AbstractInterface/server.rb
+++ b/test/OBV/AbstractInterface/server.rb
@@ -131,7 +131,7 @@ obj = passer._this()
 
 ior = orb.object_to_string(obj)
 
-open(OPTIONS[:iorfile], 'w') { |io|
+File.open(OPTIONS[:iorfile], 'w') { |io|
   io.write ior
 }
 

--- a/test/OBV/Custom/server.rb
+++ b/test/OBV/Custom/server.rb
@@ -83,7 +83,7 @@ obj = checkpoint._this()
 
 ior = orb.object_to_string(obj)
 
-open(OPTIONS[:iorfile], 'w') { |io|
+File.open(OPTIONS[:iorfile], 'w') { |io|
   io.write ior
 }
 

--- a/test/OBV/Simple/server.rb
+++ b/test/OBV/Simple/server.rb
@@ -83,7 +83,7 @@ obj = checkpoint._this()
 
 ior = orb.object_to_string(obj)
 
-open(OPTIONS[:iorfile], 'w') { |io|
+File.open(OPTIONS[:iorfile], 'w') { |io|
   io.write ior
 }
 

--- a/test/OBV/Simple_Event/server.rb
+++ b/test/OBV/Simple_Event/server.rb
@@ -83,7 +83,7 @@ obj = checkpoint._this()
 
 ior = orb.object_to_string(obj)
 
-open(OPTIONS[:iorfile], 'w') { |io|
+File.open(OPTIONS[:iorfile], 'w') { |io|
   io.write ior
 }
 

--- a/test/OBV/Supports/server.rb
+++ b/test/OBV/Supports/server.rb
@@ -86,7 +86,7 @@ obj = account._this()
 
 ior = orb.object_to_string(obj)
 
-open(OPTIONS[:iorfile], 'w') { |io|
+File.open(OPTIONS[:iorfile], 'w') { |io|
   io.write ior
 }
 

--- a/test/OBV/Tree/server.rb
+++ b/test/OBV/Tree/server.rb
@@ -100,7 +100,7 @@ obj = passer._this()
 
 ior = orb.object_to_string(obj)
 
-open(OPTIONS[:iorfile], 'w') { |io|
+File.open(OPTIONS[:iorfile], 'w') { |io|
   io.write ior
 }
 

--- a/test/OBV/Truncatable/server.rb
+++ b/test/OBV/Truncatable/server.rb
@@ -72,7 +72,7 @@ obj = tester._this()
 
 ior = orb.object_to_string(obj)
 
-open(OPTIONS[:iorfile], 'w') { |io|
+File.open(OPTIONS[:iorfile], 'w') { |io|
   io.write ior
 }
 

--- a/test/OBV/ValueBox/server.rb
+++ b/test/OBV/ValueBox/server.rb
@@ -255,7 +255,7 @@ test_obj = test_srv._this()
 
 ior = orb.object_to_string(test_obj)
 
-open(OPTIONS[:iorfile], 'w') { |io|
+File.open(OPTIONS[:iorfile], 'w') { |io|
   io.write ior
 }
 

--- a/test/Object/server.rb
+++ b/test/Object/server.rb
@@ -109,7 +109,7 @@ hello_obj = hello_srv._this()
 
 hello_ior = orb.object_to_string(hello_obj)
 
-open(OPTIONS[:iorfile], 'w') { |io|
+File.open(OPTIONS[:iorfile], 'w') { |io|
   io.write hello_ior
 }
 

--- a/test/Param_Test/server.rb
+++ b/test/Param_Test/server.rb
@@ -279,7 +279,7 @@ hello_obj = root_poa.id_to_reference(hello_oid)
 
 hello_ior = orb.object_to_string(hello_obj)
 
-open(OPTIONS[:iorfile], 'w') { |io|
+File.open(OPTIONS[:iorfile], 'w') { |io|
   io.write hello_ior
 }
 

--- a/test/Performance/Simple/server.rb
+++ b/test/Performance/Simple/server.rb
@@ -78,7 +78,7 @@ hello_obj = hello_srv._this()
 
 hello_ior = orb.object_to_string(hello_obj)
 
-open(OPTIONS[:iorfile], 'w') { |io|
+File.open(OPTIONS[:iorfile], 'w') { |io|
   io.write hello_ior
 }
 

--- a/test/Timeout/server.rb
+++ b/test/Timeout/server.rb
@@ -92,7 +92,7 @@ simple_ref = simple_srv._this()
 
 ior = orb.object_to_string(simple_ref)
 
-open(OPTIONS[:iorfile], 'w') { |io|
+File.open(OPTIONS[:iorfile], 'w') { |io|
   io.write ior
 }
 


### PR DESCRIPTION
    * test/BiDirectional/server.rb:
    * test/CORBA_Services/Naming/Corbaname/server.rb:
    * test/DII/server.rb:
    * test/DSI/client.rb:
    * test/DSI/server.rb:
    * test/Exceptions/server.rb:
    * test/Hello/server.rb:
    * test/IDL_Test/server.rb:
    * test/IORMap/server.rb:
    * test/IORTable/server.rb:
    * test/Implicit_Conversion/server.rb:
    * test/Multi_Threading/Simple/server.rb:
    * test/Multi_Threading/Threads/server.rb:
    * test/Multi_Threading/Threads/watchdog.rb:
    * test/Multiple_Servant_Interfaces/server.rb:
    * test/OBV/AbstractInterface/server.rb:
    * test/OBV/Custom/server.rb:
    * test/OBV/Simple/server.rb:
    * test/OBV/Simple_Event/server.rb:
    * test/OBV/Supports/server.rb:
    * test/OBV/Tree/server.rb:
    * test/OBV/Truncatable/server.rb:
    * test/OBV/ValueBox/server.rb:
    * test/Object/server.rb:
    * test/Param_Test/server.rb:
    * test/Performance/Simple/server.rb:
    * test/Timeout/server.rb: